### PR TITLE
feature/update-version-metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0]
+### Added
+- Documented compatibility with Kafka Connect 3.x/4.x runtimes and Java 17.
+- Hardened TLS configuration defaults and guidance for secure deployments.
+
+### Changed
+- Updated Maven project metadata to reflect community maintenance of the fork.
+- Bumped connector runtime version string to `1.1.0`.
+
+## [1.0.0]
+### Added
+- Initial release of the RabbitMQ source connector by IBM.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,47 @@
 # Kafka Connect source connector for RabbitMQ
 kafka-connect-rabbitmq-source is a [Kafka Connect](http://kafka.apache.org/documentation.html#connect) source connector for copying data from RabbitMQ into Apache Kafka.
 
+## Fork provenance and scope
+
+This repository is a community-maintained fork of IBM's original RabbitMQ source connector. It retains the core behaviour of the upstream project while layering in the upgrades required for current Kafka Connect runtimes. Recent updates include:
+
+- Dependency and toolchain alignment with Kafka Connect 3.x/4.x so the connector builds against modern Java 17-based platforms.
+- Hardened TLS configuration options and documentation to simplify secure deployments.
+
+These changes build on the original connector and aim to keep it drop-in compatible for existing deployments while signalling the additional maintenance performed in this fork.
+
 The connector is supplied as source code which you can easily build into a JAR file.
+
+## Release highlights
+
+### 1.1.0 (current)
+
+- Modernised for Kafka Connect 3.x/4.x runtimes by compiling against Java 17 APIs.
+- TLS defaults tightened with clearer guidance for supplying trust and key material.
+- Preserves drop-in compatibility with prior 1.0.x deployments while advertising the
+  fork-specific maintenance scope.
+
+See [CHANGELOG.md](CHANGELOG.md) for a full list of updates since the upstream 1.0.0
+release.
+
+## Version compatibility
+
+| Connector | Kafka Connect baseline | Java runtime |
+|-----------|------------------------|--------------|
+| 1.1.0     | 3.9.x                  | 17           |
 
 ## Installation
 
 1. Clone the repository with the following command:
 
 ```bash
-git@github.com:ibm-messaging/kafka-connect-rabbitmq-source.git
+git clone git@github.com:glokta-san/kafka-connect-rabbitmq-source.git
 ```
 
-2. Change directory to the `kafka-connect-mq-source` directory:
+2. Change directory to the `kafka-connect-rabbitmq-source` directory:
 
 ```shell
-cd kafka-connect-mq-source
+cd kafka-connect-rabbitmq-source
 ```
 
 3. Build the connector using Maven:
@@ -29,10 +56,11 @@ mvn clean package
 
 6. Setup a local rabbitmq service running on port 15672 (default)
 
-7. Copy the compiled jar file into the `/usr/local/share/java/` directory:
+7. Copy the compiled jar file into the `/usr/local/share/java/` directory. Adjust the
+   filename if you are packaging a newer release tag:
 
 ```bash
-cp target/kafka-connect-rabbitmq-source-1.0-SNAPSHOT-jar-with-dependencies.jar /usr/local/share/java/
+cp target/kafka-connect-rabbitmq-source-1.1.0-jar-with-dependencies.jar /usr/local/share/java/
 ```
 
 8. Copy the `connect-standalone.properties` and `rabbitmq-source.properties` files into the `/usr/local/etc/kafka/` directory.

--- a/pom.xml
+++ b/pom.xml
@@ -7,15 +7,15 @@
     <groupId>com.ibm.eventstreams.connect</groupId>
     <artifactId>kafka-connect-rabbitmq-source</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <name>kafka-connect-rabbitmq-source</name>
     <organization>
-        <name>IBM Corporation</name>
-        <url>http://ibm.com</url>
+        <name>Community Maintainers</name>
+        <url>https://github.com/glokta-san/kafka-connect-rabbitmq-source</url>
     </organization>
-    <url>http://ibm.com</url>
+    <url>https://github.com/glokta-san/kafka-connect-rabbitmq-source</url>
     <description>
-        A Kafka Connect connector for copying data from RabbitMQ into Apache Kafka.
+        Community-maintained fork of IBM's RabbitMQ source connector with updates for modern Kafka Connect runtimes and TLS hardening. Release 1.1.0 highlights the compatibility and TLS upgrades layered on top of the upstream project.
     </description>
     <licenses>
         <license>
@@ -24,6 +24,12 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/glokta-san/kafka-connect-rabbitmq-source.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/glokta-san/kafka-connect-rabbitmq-source.git</developerConnection>
+        <url>https://github.com/glokta-san/kafka-connect-rabbitmq-source</url>
+        <tag>HEAD</tag>
+    </scm>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/ibm/eventstreams/connect/rabbitmqsource/RabbitMQSourceConnector.java
+++ b/src/main/java/com/ibm/eventstreams/connect/rabbitmqsource/RabbitMQSourceConnector.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class RabbitMQSourceConnector extends SourceConnector {
     RabbitMQSourceConnectorConfig config;
 
-    public static String VERSION = "1.0.0";
+    public static String VERSION = "1.1.0";
 
     private Map<String, String> props;
 


### PR DESCRIPTION
## Summary
- Correct the README clone command to use `git clone` for this fork
- Clarify the jar copy step so users update the filename when packaging newer releases
- Document a version compatibility matrix to advertise the 1.1.0 baseline
- Add a CHANGELOG for release 1.1.0 and link it from the README release notes

## Testing
- mvn -q -DskipTests package
